### PR TITLE
feat: map env errs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "init4-bin-base"
 description = "Internal utilities for binaries produced by the init4 team"
 keywords = ["init4", "bin", "base"]
 
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.81"
 authors = ["init4", "James Prestwich"]

--- a/examples/ajj.rs
+++ b/examples/ajj.rs
@@ -34,6 +34,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             tracing::info!("serving hello world");
             Ok::<_, ()>("Hello, world!")
         })
+        .route("addNumbers", |(a, b): (u32, u32)| async move {
+            tracing::info!("serving addNumbers");
+            Ok::<_, ()>(a + b)
+        })
         .into_axum("/rpc");
 
     let listener = tokio::net::TcpListener::bind("localhost:8080")

--- a/src/utils/from_env.rs
+++ b/src/utils/from_env.rs
@@ -39,6 +39,17 @@ impl<Inner> FromEnvErr<Inner> {
         }
     }
 
+    /// Map the error to another type. This is useful for converting the error
+    /// type to a different type, while keeping the other error information
+    /// intact.
+    pub fn map<New>(self, f: impl FnOnce(Inner) -> New) -> FromEnvErr<New> {
+        match self {
+            Self::EnvError(s, e) => FromEnvErr::EnvError(s, e),
+            Self::Empty(s) => FromEnvErr::Empty(s),
+            Self::ParseError(e) => FromEnvErr::ParseError(f(e)),
+        }
+    }
+
     /// Missing env var.
     pub fn env_err(var: &str, e: VarError) -> Self {
         Self::EnvError(var.to_string(), e)

--- a/src/utils/otlp.rs
+++ b/src/utils/otlp.rs
@@ -134,8 +134,8 @@ impl OtelConfig {
     ///
     /// The env vars it checks are:
     /// - `OTEL_EXPORTER_OTLP_ENDPOINT` - optional. The endpoint to send traces
-    ///    to. If missing or unparsable, this function will return [`None`], and
-    ///    OTLP exporting will be disabled.
+    ///   to. If missing or unparsable, this function will return [`None`], and
+    ///   OTLP exporting will be disabled.
     /// - `OTEL_LEVEL` - optional. Specifies the minimum [`tracing::Level`] to
     ///   export. Defaults to [`tracing::Level::DEBUG`].
     /// - `OTEL_TIMEOUT` - optional. Specifies the timeout for the exporter in


### PR DESCRIPTION
Adds a convenience method to map a `FromEnvErr<T> to `FromEnvErr<U>` while preserving var issues