### PR TITLE
fix: dont eprintln

### DIFF
--- a/src/utils/otlp.rs
+++ b/src/utils/otlp.rs
@@ -61,24 +61,6 @@ impl Drop for OtelGuard {
     }
 }
 
-/// Otlp parse error.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OtlpParseError(String);
-
-impl From<String> for OtlpParseError {
-    fn from(s: String) -> Self {
-        Self(s)
-    }
-}
-
-impl core::fmt::Display for OtlpParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&format!("invalid OTLP protocol: {}", self.0))
-    }
-}
-
-impl core::error::Error for OtlpParseError {}
-
 /// Otel configuration. This struct is intended to be loaded from the env vars
 ///
 /// The env vars it checks are:
@@ -139,7 +121,7 @@ impl FromEnv for OtelConfig {
 
     fn from_env() -> Result<Self, FromEnvErr<Self::Error>> {
         // load endpoint from env. ignore empty values (shortcut return None), parse, and print the error if any using inspect_err
-        let endpoint = Url::from_env_var(OTEL_ENDPOINT).inspect_err(|e| eprintln!("{e}"))?;
+        let endpoint = Url::from_env_var(OTEL_ENDPOINT)?;
 
         let level = tracing::Level::from_env_var(OTEL_LEVEL).unwrap_or(tracing::Level::DEBUG);
 

--- a/src/utils/tracing.rs
+++ b/src/utils/tracing.rs
@@ -55,8 +55,8 @@ pub fn init_tracing() -> Option<OtelGuard> {
         install_fmt!(registry);
         Some(guard)
     } else {
-        tracing::debug!("No OTEL config found, using default tracing");
         install_fmt!(registry);
+        tracing::debug!("No OTEL config found, using default tracing");
         None
     }
 }

--- a/src/utils/tracing.rs
+++ b/src/utils/tracing.rs
@@ -56,7 +56,7 @@ pub fn init_tracing() -> Option<OtelGuard> {
         Some(guard)
     } else {
         install_fmt!(registry);
-        tracing::debug!("No OTEL config found, using default tracing");
+        tracing::debug!("No OTEL config found or error while loading otel config, using default tracing");
         None
     }
 }

--- a/src/utils/tracing.rs
+++ b/src/utils/tracing.rs
@@ -55,6 +55,7 @@ pub fn init_tracing() -> Option<OtelGuard> {
         install_fmt!(registry);
         Some(guard)
     } else {
+        tracing::debug!("No OTEL config found, using default tracing");
         install_fmt!(registry);
         None
     }

--- a/src/utils/tracing.rs
+++ b/src/utils/tracing.rs
@@ -56,7 +56,9 @@ pub fn init_tracing() -> Option<OtelGuard> {
         Some(guard)
     } else {
         install_fmt!(registry);
-        tracing::debug!("No OTEL config found or error while loading otel config, using default tracing");
+        tracing::debug!(
+            "No OTEL config found or error while loading otel config, using default tracing"
+        );
         None
     }
 }


### PR DESCRIPTION
Removes the misleading eprintln and adds a debug after installing tracing to indicate that otel was skipped