### PR TITLE
chore(deps): pin alloy to sdk version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ repository = "https://github.com/init4tech/bin-base"
 init4-from-env-derive =  "0.1.0"
 
 # Signet
-signet-constants = { version = "0.4.0" }
-signet-tx-cache = { version = "0.4.0", optional = true }
+signet-constants = { version = "0.4.2" }
+signet-tx-cache = { version = "0.4.2", optional = true }
 
 # Tracing
 tracing = "0.1.40"
@@ -45,7 +45,7 @@ tokio = { version = "1.36.0", optional = true }
 
 # Other
 thiserror = "2.0.11"
-alloy = { version = "1.0.5", optional = true, default-features = false, features = ["std", "signer-aws", "signer-local", "consensus", "network"] }
+alloy = { version = "=1.0.11", optional = true, default-features = false, features = ["std", "signer-aws", "signer-local", "consensus", "network"] }
 serde = { version = "1", features = ["derive"] }
 async-trait = { version = "0.1.80", optional = true }
 eyre = { version = "0.6.12", optional = true }


### PR DESCRIPTION
We now need to pin the alloy version so this compiles correctly.