### PR TITLE
fix: infallible structs in derive macro

### DIFF
--- a/from-env-derive/Cargo.toml
+++ b/from-env-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "init4-from-env-derive"
 
 description = "A derive macro for `init4_bin_base::FromEnv`"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.81"
 authors = ["init4", "James Prestwich"]
@@ -20,4 +20,4 @@ syn = { version = "2.0.100", features = ["full", "parsing"] }
 proc-macro = true
 
 [dev-dependencies]
-init4-bin-base = "0.3"
+init4-bin-base = "0.9"

--- a/from-env-derive/src/field.rs
+++ b/from-env-derive/src/field.rs
@@ -114,7 +114,7 @@ impl Field {
             return field_name.clone();
         }
 
-        let n = format!("field_{}", idx);
+        let n = format!("field_{idx}");
         syn::parse_str::<Ident>(&n)
             .map_err(|_| syn::Error::new(self.span, "Failed to create field name"))
             .unwrap()

--- a/from-env-derive/src/field.rs
+++ b/from-env-derive/src/field.rs
@@ -199,7 +199,7 @@ impl Field {
         })
     }
 
-    pub(crate) fn expand_item_from_env(&self, err_ident: &Ident, idx: usize) -> TokenStream {
+    pub(crate) fn expand_item_from_env(&self, err_ident: &syn::Path, idx: usize) -> TokenStream {
         // Produces code fo the following form:
         // ```rust
         // // EITHER

--- a/from-env-derive/tests/macro.rs
+++ b/from-env-derive/tests/macro.rs
@@ -92,10 +92,10 @@ mod test {
     }
 
     fn assert_contains(vec: &Vec<&'static EnvItemInfo>, item: &EnvItemInfo) {
-        let item = vec.iter().find(|i| i.var == item.var).unwrap();
-        assert_eq!(item.var, item.var);
-        assert_eq!(item.description, item.description);
-        assert_eq!(item.optional, item.optional);
+        let i = vec.iter().find(|i| i.var == item.var).unwrap();
+        assert_eq!(i.var, item.var);
+        assert_eq!(i.description, item.description);
+        assert_eq!(i.optional, item.optional);
     }
 
     #[test]

--- a/from-env-derive/tests/macro.rs
+++ b/from-env-derive/tests/macro.rs
@@ -1,5 +1,16 @@
 use init4_from_env_derive::FromEnv;
 
+// Compile check for a struct with no fallible fields (and therefore no
+// associated env error).
+#[derive(Debug, FromEnv)]
+pub struct InfallibleConfig {
+    #[from_env(var = "INTERNAL", desc = "An infallible string", infallible)]
+    pub internal: String,
+
+    #[from_env(var = "INTERNAL_COW", desc = "An infallible Cow<str>", infallible)]
+    pub internal_cow: std::borrow::Cow<'static, str>,
+}
+
 #[derive(FromEnv, Debug)]
 pub struct FromEnvTest {
     /// This is a guy named tony


### PR DESCRIPTION
Improves the FromEnv derive to work with structs that contain only infallible members