### PR TITLE
fix: install rustls provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "init4-bin-base"
 description = "Internal utilities for binaries produced by the init4 team"
 keywords = ["init4", "bin", "base"]
 
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.81"
 authors = ["init4", "James Prestwich"]
@@ -56,6 +56,7 @@ tower = { version = "0.5.2", optional = true }
 aws-config = { version = "1.1.7", optional = true }
 aws-sdk-kms = { version = "1.15.0", optional = true }
 reqwest = { version = "0.12.15", optional = true }
+rustls = { version = "0.23.31", optional = true }
 
 [dev-dependencies]
 ajj = "0.3.1"
@@ -66,9 +67,10 @@ signal-hook = "0.3.17"
 tokio = { version = "1.43.0", features = ["macros"] }
 
 [features]
-default = ["alloy"]
+default = ["alloy", "rustls"]
 alloy = ["dep:alloy", "dep:async-trait", "dep:aws-config", "dep:aws-sdk-kms"]
 perms = ["dep:oauth2", "dep:tokio", "dep:reqwest", "dep:signet-tx-cache", "dep:eyre", "dep:axum", "dep:tower"]
+rustls = ["dep:rustls", "rustls/aws-lc-rs"]
 
 [[example]]
 name = "oauth"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,5 +81,11 @@ pub mod deps {
 pub fn init4() -> Option<utils::otlp::OtelGuard> {
     let guard = utils::tracing::init_tracing();
     utils::metrics::init_metrics();
+
+    // This will install the AWS-LC-Rust TLS provider for rustls, if no other
+    // provider has been installed yet
+    #[cfg(feature = "rustls")]
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     guard
 }


### PR DESCRIPTION
Make `init4()` install aws-lc-rs as the default rustls provider, if no other provider has been installed yet.