### PR TITLE
chore: bump sdk to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "init4-bin-base"
 description = "Internal utilities for binaries produced by the init4 team"
 keywords = ["init4", "bin", "base"]
 
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.81"
 authors = ["init4", "James Prestwich"]
@@ -16,8 +16,11 @@ repository = "https://github.com/init4tech/bin-base"
 init4-from-env-derive =  "0.1.0"
 
 # Signet
-signet-constants = { version = "0.9.0" }
-signet-tx-cache = { version = "0.9.0", optional = true }
+signet-constants = { version = "0.10.0" }
+signet-tx-cache = { version = "0.10.0", optional = true }
+
+# alloy
+alloy = { version = "1.0.25", optional = true, default-features = false, features = ["std", "signer-aws", "signer-local", "consensus", "network"] }
 
 # Tracing
 tracing = "0.1.40"
@@ -45,7 +48,6 @@ tokio = { version = "1.36.0", optional = true }
 
 # Other
 thiserror = "2.0.11"
-alloy = { version = "1.0.11", optional = true, default-features = false, features = ["std", "signer-aws", "signer-local", "consensus", "network"] }
 serde = { version = "1", features = ["derive"] }
 async-trait = { version = "0.1.80", optional = true }
 eyre = { version = "0.6.12", optional = true }
@@ -81,3 +83,13 @@ required-features = ["perms"]
 name = "tx_cache"
 path = "examples/tx_cache.rs"
 required-features = ["perms"]
+
+
+# [patch.crates-io]
+# signet-bundle = { path = "../sdk/crates/bundle"}
+# signet-constants = { path = "../sdk/crates/constants"}
+# signet-evm = { path = "../sdk/crates/evm"}
+# signet-extract = { path = "../sdk/crates/extract"}
+# signet-tx-cache = { path = "../sdk/crates/tx-cache"}
+# signet-types = { path = "../sdk/crates/types"}
+# signet-zenith = { path = "../sdk/crates/zenith"}


### PR DESCRIPTION
bump sdk ot 0.10 to support reth 1.6