### PR TITLE
feat(calc): manual `FromEnv` impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "init4-bin-base"
 description = "Internal utilities for binaries produced by the init4 team"
 keywords = ["init4", "bin", "base"]
 
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 rust-version = "1.81"
 authors = ["init4", "James Prestwich", "evalir"]

--- a/src/utils/calc.rs
+++ b/src/utils/calc.rs
@@ -290,7 +290,6 @@ impl FromEnv for SlotCalculator {
             return Ok(slot_calculator);
         }
 
-        // Else, look for the individual chain constants
         let start_timestamp = FromEnvVar::from_env_var("START_TIMESTAMP")?;
         let slot_offset = FromEnvVar::from_env_var("SLOT_OFFSET")?;
         let slot_duration = FromEnvVar::from_env_var("SLOT_DURATION")?;

--- a/src/utils/calc.rs
+++ b/src/utils/calc.rs
@@ -268,19 +268,24 @@ impl FromEnv for SlotCalculator {
     fn inventory() -> Vec<&'static EnvItemInfo> {
         vec![
             &EnvItemInfo {
+                var: "CHAIN_NAME",
+                description: "The name of the chain. If set, the other environment variables are ignored.",
+                optional: true,
+            },
+            &EnvItemInfo {
                 var: "START_TIMESTAMP",
-                description: "The start timestamp of the chain in seconds",
-                optional: false,
+                description: "The start timestamp of the chain in seconds. Required if CHAIN_NAME is not set.",
+                optional: true,
             },
             &EnvItemInfo {
                 var: "SLOT_OFFSET",
-                description: "The number of the slot containing the start timestamp",
-                optional: false,
+                description: "The number of the slot containing the start timestamp. Required if CHAIN_NAME is not set.",
+                optional: true,
             },
             &EnvItemInfo {
                 var: "SLOT_DURATION",
-                description: "The slot duration of the chain in seconds",
-                optional: false,
+                description: "The slot duration of the chain in seconds. Required if CHAIN_NAME is not set.",
+                optional: true,
             },
         ]
     }


### PR DESCRIPTION
Implements `FromEnv` manually for the calculator. It now has the following behavior:

- First, the `CHAIN_NAME` environment variable is checked. If it's present, instantiation from the chain name is attempted.
- If the `CHAIN_NAME` environment variable is not present, the individual environment variables used to configure the calculator are looked up, and the calculator is instantiated. Any of these missing results in a hard error.