### PR TITLE
feat: handle KnownChains::Gouda; bump signet-sdk 0.19.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ init4-from-env-derive = { version = "0.2.0", path = "from-env-derive" }
 
 # Signet
 signet-cold-sql = { git = "https://github.com/init4tech/storage", rev = "7841fabdd71dd5b58a7bd21ccd9b7d25d11ddc55", optional = true, default-features = false, features = ["postgres", "sqlite"] }
-signet-constants = { git = "https://github.com/init4tech/signet-sdk", rev = "8a85a4636bccf971226a9c80c311832ce33e998c" }
+signet-constants = { git = "https://github.com/init4tech/signet-sdk", rev = "3489c6b" }
 signet-tx-cache = { version = "0.18.0", optional = true }
 
 # alloy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/init4tech/bin-base"
 init4-from-env-derive = { version = "0.2.0", path = "from-env-derive" }
 
 # Signet
-signet-cold-sql = { version = "0.9.0", optional = true, default-features = false, features = ["postgres", "sqlite"] }
+signet-cold-sql = { git = "https://github.com/init4tech/storage", rev = "7841fabdd71dd5b58a7bd21ccd9b7d25d11ddc55", optional = true, default-features = false, features = ["postgres", "sqlite"] }
 signet-constants = { git = "https://github.com/init4tech/signet-sdk", rev = "8a85a4636bccf971226a9c80c311832ce33e998c" }
 signet-tx-cache = { version = "0.18.0", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ init4-from-env-derive = { version = "0.2.0", path = "from-env-derive" }
 
 # Signet
 signet-cold-sql = { version = "0.9.0", optional = true, default-features = false, features = ["postgres", "sqlite"] }
-signet-constants = { version = "0.18.0" }
+signet-constants = { git = "https://github.com/init4tech/signet-sdk", rev = "8a85a4636bccf971226a9c80c311832ce33e998c" }
 signet-tx-cache = { version = "0.18.0", optional = true }
 
 # alloy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ init4-from-env-derive = { version = "0.2.0", path = "from-env-derive" }
 
 # Signet
 signet-cold-sql = { git = "https://github.com/init4tech/storage", rev = "5ab8f75e2e89628b60128204132a8186afff1a4f", optional = true, default-features = false, features = ["postgres", "sqlite"] }
-signet-constants = { git = "https://github.com/init4tech/signet-sdk", rev = "3489c6b" }
+signet-constants = { git = "https://github.com/init4tech/signet-sdk", rev = "ecce6a48a6af81c5f668c142b3a63452de02a146" }
 signet-tx-cache = { version = "0.18.0", optional = true }
 
 # alloy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/init4tech/bin-base"
 init4-from-env-derive = { version = "0.2.0", path = "from-env-derive" }
 
 # Signet
-signet-cold-sql = { git = "https://github.com/init4tech/storage", rev = "7841fabdd71dd5b58a7bd21ccd9b7d25d11ddc55", optional = true, default-features = false, features = ["postgres", "sqlite"] }
+signet-cold-sql = { git = "https://github.com/init4tech/storage", rev = "5ab8f75e2e89628b60128204132a8186afff1a4f", optional = true, default-features = false, features = ["postgres", "sqlite"] }
 signet-constants = { git = "https://github.com/init4tech/signet-sdk", rev = "3489c6b" }
 signet-tx-cache = { version = "0.18.0", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/init4tech/bin-base"
 init4-from-env-derive = { version = "0.2.0", path = "from-env-derive" }
 
 # Signet
-signet-cold-sql = { git = "https://github.com/init4tech/storage", rev = "5ab8f75e2e89628b60128204132a8186afff1a4f", optional = true, default-features = false, features = ["postgres", "sqlite"] }
+signet-cold-sql = { git = "https://github.com/init4tech/storage", rev = "d5bf6fa", optional = true, default-features = false, features = ["postgres", "sqlite"] }
 signet-constants = { git = "https://github.com/init4tech/signet-sdk", rev = "ecce6a48a6af81c5f668c142b3a63452de02a146" }
 signet-tx-cache = { version = "0.18.0", optional = true }
 

--- a/src/utils/calc.rs
+++ b/src/utils/calc.rs
@@ -340,6 +340,7 @@ impl From<KnownChains> for SlotCalculator {
         match value {
             KnownChains::Mainnet => SlotCalculator::mainnet(),
             KnownChains::Parmigiana => SlotCalculator::parmigiana_host(),
+            KnownChains::Gouda => SlotCalculator::parmigiana_host(),
             #[allow(deprecated)]
             KnownChains::Pecorino => SlotCalculator::pecorino_host(),
             KnownChains::Test => SlotCalculator::new(


### PR DESCRIPTION
## Summary
- Adds `KnownChains::Gouda => SlotCalculator::parmigiana_host()` arm in `src/utils/calc.rs` (delegates to parmigiana host).

## Test plan
- [x] cargo test --workspace --all-targets green
- [x] cargo fmt --check, cargo clippy -- -D warnings clean

## Related branches
- signet-sdk#236 (adds the Gouda variant being matched here)
- storage feat/gouda-sdk-deps (provides the storage crates this branch pins)

🤖 Generated with Claude Code